### PR TITLE
print application-level errors when using HTTP

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -185,11 +185,17 @@ func (c *Command) post(method string, req interface{}) error {
 
 	res := struct {
 		Result interface{} `json:"result"`
+		Error  interface{} `json:"error"`
 	}{}
 
 	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
 		return err
+	}
+
+	if res.Error != nil {
+		fmt.Printf("%+v\n", res.Error)
+		return nil
 	}
 
 	buf, err := json.MarshalIndent(res.Result, "", "  ")


### PR DESCRIPTION
Currently, if an application-level error (eg: validation) occurs when using HTTP, it simply prints `null`. (since that is what `result` is) This basically adds another condition prior to printing the result, which prints the error if there is one.

/cc @yields
