### PR TITLE
feat: use json number in decoder to support large numbers better

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -55,6 +55,7 @@ func (c *Command) Run() error {
 	}
 
 	dec := json.NewDecoder(c.Input)
+	dec.UseNumber()
 
 	for {
 		var req interface{}
@@ -188,7 +189,9 @@ func (c *Command) post(method string, req interface{}) error {
 		Error  interface{} `json:"error"`
 	}{}
 
-	err = json.NewDecoder(resp.Body).Decode(&res)
+	dec := json.NewDecoder(resp.Body)
+	dec.UseNumber()
+	err = dec.Decode(&res)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Right now, you pass large numbers (like unix timestamps) to rpc-cli, you'll get those numbers marshaled in e-notation, which breaks during unmarshal on the other side of the wire.

I believe this should fix that by using `json.Number` in both json decoders.