### PR TITLE
feat: add User-Agent header

### DIFF
--- a/cmd/rpc/main.go
+++ b/cmd/rpc/main.go
@@ -45,6 +45,7 @@ func main() {
 	cmd.Addr = addr
 	cmd.Method, _ = args["<method>"].(string)
 	cmd.Args, _ = args["<args>"].([]string)
+	cmd.UserAgent = fmt.Sprintf("Segment (rpc-cli/%s", version)
 
 	check(cmd.Run())
 }

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -20,6 +20,7 @@ type Command struct {
 	Addr        string
 	Method      string
 	Args        []string
+	UserAgent   string
 	HTTP        bool
 	Interactive bool
 	Input       io.Reader
@@ -170,6 +171,10 @@ func (c *Command) post(method string, req interface{}) error {
 	}
 
 	r.Header.Set("Content-Type", "application/json")
+	if c.UserAgent != "" {
+		r.Header.Set("User-Agent", c.UserAgent)
+	}
+
 	resp, err := http.DefaultClient.Do(r)
 	if resp != nil {
 		defer resp.Body.Close()


### PR DESCRIPTION
This adds a Segment-style user-agent string that allows this CLI to be used with DCS. Making it configurable was hard because of docopt, so I'm just going to pass on that for now since this is a legacy tool anyways.